### PR TITLE
Add functionality to change image after initialisation.

### DIFF
--- a/MGSpotyViewController/MGSpotyViewController.h
+++ b/MGSpotyViewController/MGSpotyViewController.h
@@ -18,5 +18,6 @@ extern CGFloat const kMGOffsetBlurEffect;
 @property (nonatomic, strong) UIImageView *mainImageView;
 
 - (instancetype)initWithMainImage:(UIImage *)image;
+- (void)setMainImage:(UIImage *)image;
 
 @end

--- a/MGSpotyViewController/MGSpotyViewController.m
+++ b/MGSpotyViewController/MGSpotyViewController.m
@@ -77,6 +77,10 @@ CGFloat const kMGOffsetBlurEffect = 2.0;
     }
 }
 
+- (void)setMainImage:(UIImage *)image {
+    _image = [image copy];
+    [_mainImageView setImageToBlur:_image blurRadius:kLBBlurredImageDefaultBlurRadius completionBlock:nil];
+}
 
 #pragma mark - UIScrollView Delegate
 


### PR DESCRIPTION
This change allows you to replace the image after initialisation of MGSpotyViewController. This is useful if you don't have the image when creating MGSpotyViewController (you can use a placeholder) or if you want to change the image - lets say a user changes their profile picture. 

This request is from a feature specific branch that won't pick up the other changes I made.
